### PR TITLE
Save high score for random levels

### DIFF
--- a/app/src/main/java/com/picross/nonocross/HighScoreManager.kt
+++ b/app/src/main/java/com/picross/nonocross/HighScoreManager.kt
@@ -1,0 +1,37 @@
+package com.picross.nonocross
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import com.picross.nonocross.util.usergrid.UserGrid
+
+object HighScoreManager {
+    private const val NO_SCORE = -1L
+
+    private fun preferenceKeyForHighScore(height: Int, width: Int, difficulty: Int) =
+        "high_score-$height-$width-$difficulty"
+
+    fun handleNewScore(context: Context, grid: UserGrid, difficulty: Int): Boolean {
+        val key = preferenceKeyForHighScore(grid.height, grid.width, difficulty)
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val currentHigh = preferences.getLong(key, NO_SCORE)
+        val time = grid.timeElapsed.toLong()
+        if (currentHigh == NO_SCORE || time < currentHigh) {
+            preferences.edit {
+                putLong(key, time)
+            }
+            return true
+        }
+        return false
+    }
+
+    fun getHighScore(context: Context, height: Int, width: Int, difficulty: Int): UInt? {
+        val key = preferenceKeyForHighScore(height, width, difficulty)
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val currentHigh = preferences.getLong(key, NO_SCORE)
+        if (currentHigh == NO_SCORE) {
+            return null
+        }
+        return currentHigh.toUInt()
+    }
+}

--- a/app/src/main/java/com/picross/nonocross/MainActivity.kt
+++ b/app/src/main/java/com/picross/nonocross/MainActivity.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.widget.NumberPicker
+import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -31,7 +32,12 @@ import androidx.preference.PreferenceManager
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Some
-import com.picross.nonocross.util.*
+import com.picross.nonocross.util.errorToast
+import com.picross.nonocross.util.getRandomGridPrefs
+import com.picross.nonocross.util.newRandomGrid
+import com.picross.nonocross.util.newUniqueRandomGrid
+import com.picross.nonocross.util.openGridFile
+import com.picross.nonocross.util.secondsToTime
 import com.picross.nonocross.util.usergrid.GridData
 import com.picross.nonocross.util.usergrid.UserGrid
 import com.picross.nonocross.util.usergrid.toGridData
@@ -113,6 +119,7 @@ class MainActivity : AppCompatActivity() {
         val rowsPicker = dialogView.findViewById<NumberPicker>(R.id.rows_picker)
         val colsPicker = dialogView.findViewById<NumberPicker>(R.id.cols_picker)
         val diffPicker = dialogView.findViewById<NumberPicker>(R.id.difficulty_picker)
+        val highscoreTextView = dialogView.findViewById<TextView>(R.id.highscore)
         rowsPicker.maxValue = 25
         rowsPicker.minValue = 2
         rowsPicker.value = preferences.getInt("rows", 10)
@@ -125,6 +132,25 @@ class MainActivity : AppCompatActivity() {
         diffPicker.minValue = 1
         diffPicker.value = preferences.getInt("difficulty", 5)
         diffPicker.wrapSelectorWheel = false
+
+        fun updateHighScore() {
+            val highScore = HighScoreManager.getHighScore(this, rowsPicker.value, colsPicker.value, diffPicker.value)
+            highscoreTextView.text = if (highScore == null) {
+                getString(R.string.no_high_score)
+            } else {
+                getString(R.string.high_score, secondsToTime(highScore))
+            }
+        }
+
+        val listener = NumberPicker.OnValueChangeListener { _, _, _ ->
+            updateHighScore()
+        }
+
+        rowsPicker.setOnValueChangedListener(listener)
+        colsPicker.setOnValueChangedListener(listener)
+        diffPicker.setOnValueChangedListener(listener)
+        updateHighScore()
+
         AlertDialog.Builder(this@MainActivity)
             .setTitle(R.string.grid_size)
             .setView(dialogView)

--- a/app/src/main/java/com/picross/nonocross/util/usergrid/UserGrid.kt
+++ b/app/src/main/java/com/picross/nonocross/util/usergrid/UserGrid.kt
@@ -15,7 +15,7 @@ class UserGrid(private val gridData: GridData, initialState: ByteArray = byteArr
     var complete: Boolean
     var timeElapsed: UInt
 
-    private val height = gridData.height
+    val height = gridData.height
     val width = gridData.width
     val size = gridData.width * gridData.height
 

--- a/app/src/main/java/com/picross/nonocross/views/grid/GridView.kt
+++ b/app/src/main/java/com/picross/nonocross/views/grid/GridView.kt
@@ -33,9 +33,11 @@ import com.picross.nonocross.GameActivity
 import com.picross.nonocross.GameActivity.TransformDetails.mScaleFactor
 import com.picross.nonocross.GameActivity.TransformDetails.mTransX
 import com.picross.nonocross.GameActivity.TransformDetails.mTransY
+import com.picross.nonocross.HighScoreManager
 import com.picross.nonocross.LevelType
 import com.picross.nonocross.R
 import com.picross.nonocross.util.CellShade
+import com.picross.nonocross.util.getRandomGridPrefs
 import com.picross.nonocross.util.secondsToTime
 import com.picross.nonocross.util.usergrid.UserGridView
 import com.picross.nonocross.util.vibrate
@@ -242,6 +244,8 @@ class GridView @JvmOverloads constructor(
 
     /** When the game is finished show a dialog */
     private fun gameDoneAlert() {
+        HighScoreManager.handleNewScore(context, LD.userGrid, getRandomGridPrefs(context).third)
+
         LD.userGrid.complete = true
         val done = AlertDialog.Builder(context)
             .setTitle(R.string.finished)

--- a/app/src/main/res/layout/dialogue_random_grid.xml
+++ b/app/src/main/res/layout/dialogue_random_grid.xml
@@ -85,6 +85,18 @@ along with Nonocross.  If not, see <https://www.gnu.org/licenses/>.-->
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/difficultyTextView" />
 
+        <TextView
+            android:id="@+id/highscore"
+            tools:text="Highscore: 1:23"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/difficulty_picker"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="8dp" />
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="not_save">Don\'t save</string>
     <string name="easy">Easy %1$d</string>
     <string name="level">Level %1$d</string>
+    <string name="high_score">High-score %s</string>
+    <string name="no_high_score">No high-score</string>
     <string-array name="fill_mode_entries">
         <item>Default</item>
         <item>Lax</item>


### PR DESCRIPTION
I used SharedPreferences to save the high score because:
1. That's not much data.
2. The backup solution for the settings also backs up the high scores.

Closes #63 