### PR TITLE
Refactor settings handling

### DIFF
--- a/app/src/main/java/com/picross/nonocross/HighScoreManager.kt
+++ b/app/src/main/java/com/picross/nonocross/HighScoreManager.kt
@@ -2,7 +2,7 @@ package com.picross.nonocross
 
 import android.content.Context
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
+import com.picross.nonocross.util.Preferences
 import com.picross.nonocross.util.usergrid.UserGrid
 
 object HighScoreManager {
@@ -13,7 +13,7 @@ object HighScoreManager {
 
     fun handleNewScore(context: Context, grid: UserGrid, difficulty: Int): Boolean {
         val key = preferenceKeyForHighScore(grid.height, grid.width, difficulty)
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val preferences = Preferences(context).sharedPrefs
         val currentHigh = preferences.getLong(key, NO_SCORE)
         val time = grid.timeElapsed.toLong()
         if (currentHigh == NO_SCORE || time < currentHigh) {
@@ -27,7 +27,7 @@ object HighScoreManager {
 
     fun getHighScore(context: Context, height: Int, width: Int, difficulty: Int): UInt? {
         val key = preferenceKeyForHighScore(height, width, difficulty)
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val preferences = Preferences(context).sharedPrefs
         val currentHigh = preferences.getLong(key, NO_SCORE)
         if (currentHigh == NO_SCORE) {
             return null

--- a/app/src/main/java/com/picross/nonocross/levelselect/CustomLevelSelectAdapter.kt
+++ b/app/src/main/java/com/picross/nonocross/levelselect/CustomLevelSelectAdapter.kt
@@ -22,11 +22,11 @@ import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.view.get
-import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 import com.picross.nonocross.LevelDetails
 import com.picross.nonocross.LevelType
 import com.picross.nonocross.R
+import com.picross.nonocross.util.Preferences
 import com.picross.nonocross.util.getLevelName
 import com.picross.nonocross.util.usergrid.GridData
 import com.picross.nonocross.util.usergrid.UserGrid
@@ -94,9 +94,12 @@ class CustomLevelSelectAdapter(
                 LevelDetails.levelType = startGame.levelType(levelName)
                 LevelDetails.gridData = level
                 LevelDetails.userGrid =
-                    UserGrid(LevelDetails.gridData, startGame.openSave(levelName),
+                    UserGrid(
+                        LevelDetails.gridData,
+                        startGame.openSave(levelName),
                         LevelDetails.levelType !is LevelType.Default,
-                    PreferenceManager.getDefaultSharedPreferences(context).getBoolean("resetComplete", true))
+                        Preferences(context).resetComplete
+                    )
                 startGame.startGame()
             }
             if (startGame.isCustom) {

--- a/app/src/main/java/com/picross/nonocross/util/Preferences.kt
+++ b/app/src/main/java/com/picross/nonocross/util/Preferences.kt
@@ -1,0 +1,113 @@
+package com.picross.nonocross.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.AppCompatDelegate.NightMode
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+
+class Preferences(context: Context) {
+    var sharedPrefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        private set
+
+    val vibrate: Boolean
+        get() {
+            return sharedPrefs.getBoolean("vibrate", false)
+        }
+
+    val fatFingerMode: Boolean
+        get() {
+            return sharedPrefs.getBoolean("fatFinger", true)
+        }
+
+    val uniqueLevel: Boolean
+        get() {
+            return sharedPrefs.getBoolean("uniqueLevel", true)
+        }
+
+    val resetComplete: Boolean
+        get() {
+            return sharedPrefs.getBoolean("resetComplete", true)
+        }
+
+    val enableZoom: Boolean
+        get() {
+            return sharedPrefs.getBoolean("enable_zoom", true)
+        }
+
+    val fillMode: FillMode
+        get() {
+            return when(sharedPrefs.getString("fillMode", "")) {
+                "Lax" -> FillMode.Lax
+                "Strict" -> FillMode.Strict
+                else -> FillMode.Default
+            }
+        }
+
+    enum class FillMode {
+        Default,
+        Lax,
+        Strict
+    }
+
+    @NightMode
+    val theme: Int
+        get() {
+            return when (sharedPrefs.getString("darkMode2", "")) {
+                "Dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                "Light" -> AppCompatDelegate.MODE_NIGHT_NO
+                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            }
+        }
+
+    val showHints: Boolean
+        get() {
+            return sharedPrefs.getBoolean("showBlueHints", false)
+        }
+
+    val showSaveWarning: Boolean
+        get() {
+            return sharedPrefs.getBoolean("saveWarn", true)
+        }
+
+    val trackTimer: Boolean
+        get() {
+            return sharedPrefs.getBoolean("tracktimer", true)
+        }
+
+    val showTimer: Boolean
+        get() {
+            return sharedPrefs.getBoolean("timer", true)
+        }
+
+    var randomGridWidth: Int
+        get() {
+            return sharedPrefs.getInt("columns", 10)
+        }
+        set(value) {
+            sharedPrefs.edit {
+                putInt("columns", value)
+            }
+        }
+
+    var randomGridHeight: Int
+        get() {
+            return sharedPrefs.getInt("rows", 10)
+        }
+        set(value) {
+            sharedPrefs.edit {
+                putInt("rows", value)
+            }
+        }
+
+    var randomGridDifficulty: Int
+        get() {
+            return sharedPrefs.getInt("difficulty", 5)
+        }
+        set(value) {
+            sharedPrefs.edit {
+                putInt("difficulty", value)
+            }
+        }
+}

--- a/app/src/main/java/com/picross/nonocross/util/Util.kt
+++ b/app/src/main/java/com/picross/nonocross/util/Util.kt
@@ -29,7 +29,6 @@ import android.util.TypedValue
 import android.widget.Toast
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
-import androidx.preference.PreferenceManager
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option
@@ -73,11 +72,12 @@ fun newRandomGrid(wHD: Triple<Int, Int, Int>, random: Random = Random) =
     }
 
 fun getRandomGridPrefs(context: Context): Triple<Int, Int, Int> {
-    val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-    val width = preferences.getInt("columns", 10)
-    val height = preferences.getInt("rows", 10)
-    val difficulty = preferences.getInt("difficulty", 5)
-    return Triple(width, height, difficulty)
+    val preferences = Preferences(context)
+    return Triple(
+        preferences.randomGridWidth,
+        preferences.randomGridHeight,
+        preferences.randomGridDifficulty
+    )
 }
 
 fun readTextFromUri(uri: Uri, context: Context): String {

--- a/app/src/main/java/com/picross/nonocross/util/usergrid/UserGrid.kt
+++ b/app/src/main/java/com/picross/nonocross/util/usergrid/UserGrid.kt
@@ -5,6 +5,7 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.none
 import com.picross.nonocross.util.CellShade
+import com.picross.nonocross.util.Preferences
 import com.picross.nonocross.util.click
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
@@ -149,16 +150,16 @@ class UserGrid(private val gridData: GridData, initialState: ByteArray = byteArr
     }
 
     private fun fillRow(row: Int, cellShade: CellShade) =
-        copyInSlice(row * width until (row + 1) * width, cellShade, CellShade.EMPTY, 0)
+        copyInSlice(row * width until (row + 1) * width, cellShade, CellShade.EMPTY, Preferences.FillMode.Lax)
 
     private fun fillCol(col: Int, cellShade: CellShade) =
-        copyInSlice(col until col + height * width step width, cellShade, CellShade.EMPTY, 0)
+        copyInSlice(col until col + height * width step width, cellShade, CellShade.EMPTY, Preferences.FillMode.Lax)
 
     fun copyRowInRange(
         index1: Int,
         index2: Int,
         initShade: CellShade,
-        mode: Int
+        mode: Preferences.FillMode
     ) {
         val initCol = index1 % width
         val currCol = index2 % width
@@ -175,7 +176,7 @@ class UserGrid(private val gridData: GridData, initialState: ByteArray = byteArr
         index1: Int,
         index2: Int,
         initShade: CellShade,
-        mode: Int
+        mode: Preferences.FillMode
     ) {
         val initRow = index1 / width
         val currRow = index2 / width
@@ -192,13 +193,13 @@ class UserGrid(private val gridData: GridData, initialState: ByteArray = byteArr
         slice: Iterable<Int>,
         cellShade: CellShade,
         initShade: CellShade,
-        mode: Int
+        mode: Preferences.FillMode
     ) {
-        if (mode == 0 || (mode == 1 && cellShade == CellShade.EMPTY)) {
+        if (mode == Preferences.FillMode.Lax || (mode == Preferences.FillMode.Default && cellShade == CellShade.EMPTY)) {
             for(index in slice) {
                 grid = grid.set(index, cellShade)
             }
-        } else if (mode == 1) {
+        } else if (mode == Preferences.FillMode.Default) {
             for(index in slice){
                 grid = grid.set(index, (if (grid[index] == CellShade.EMPTY) cellShade else grid[index]))
             }

--- a/app/src/main/java/com/picross/nonocross/views/grid/AbstractNumsView.kt
+++ b/app/src/main/java/com/picross/nonocross/views/grid/AbstractNumsView.kt
@@ -1,0 +1,44 @@
+package com.picross.nonocross.views.grid
+
+import android.content.Context
+import android.graphics.Paint
+import android.graphics.Picture
+import android.view.View
+import com.picross.nonocross.R
+import com.picross.nonocross.util.Preferences
+import com.picross.nonocross.util.resolveThemedColor
+
+abstract class AbstractNumsView(context: Context) : View(context) {
+    private val preferences = Preferences(context)
+    protected val showHints = preferences.showHints
+    protected val enableZoom = preferences.enableZoom
+
+    protected val paintNumber = Paint()
+        .apply { color = context.resolveThemedColor(R.attr.colorOnSurface) }
+        .apply { isAntiAlias = true }
+        .apply { textAlign = Paint.Align.CENTER }
+    protected val paintShade = Paint()
+        .apply { color = context.resolveThemedColor(R.attr.colorPrimary) }
+        .apply { isAntiAlias = true }
+        .apply { textAlign = Paint.Align.CENTER }
+    protected val paintCross = Paint()
+        .apply { color = context.resolveThemedColor(R.attr.colorCross) }
+        .apply { isAntiAlias = true }
+        .apply { textAlign = Paint.Align.CENTER }
+
+    var cellLength = 0
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (changed) {
+            paintNumber.apply { textSize = cellLength * 0.5F }
+            paintShade.apply { textSize = cellLength * 0.5F }
+            paintCross.apply { textSize = cellLength * 0.5F }
+        }
+    }
+
+    protected lateinit var templateNumber: MutableList<Picture>
+    protected lateinit var templateShade: MutableList<Picture>
+    protected lateinit var templateCross: MutableList<Picture>
+    var refreshTemplates = true
+}

--- a/app/src/main/java/com/picross/nonocross/views/grid/ColNumsView.kt
+++ b/app/src/main/java/com/picross/nonocross/views/grid/ColNumsView.kt
@@ -16,55 +16,17 @@ package com.picross.nonocross.views.grid
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.SharedPreferences
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Picture
 import android.view.MotionEvent
-import android.view.View
-import androidx.preference.PreferenceManager
 import com.picross.nonocross.GameActivity.TransformDetails.mScaleFactor
 import com.picross.nonocross.GameActivity.TransformDetails.mTransX
-import com.picross.nonocross.R
-import com.picross.nonocross.util.resolveThemedColor
 import kotlin.math.max
 import kotlin.math.min
 import com.picross.nonocross.LevelDetails as LD
 
-class ColNumsView(context: Context) : View(context) {
-
-    private val preferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(context)
-    private val showHints = preferences.getBoolean("showBlueHints", false)
-    private val enableZoom = preferences.getBoolean("enable_zoom", true)
-
-    var cellLength = 0
-    private val colorNumber = context.resolveThemedColor(R.attr.colorOnSurface)
-    private val colorShade = context.resolveThemedColor(R.attr.colorPrimary)
-    private val colorCross = context.resolveThemedColor(R.attr.colorCross)
-    private val paintNumber = Paint()
-        .apply { color = colorNumber }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.CENTER }
-    private val paintShade = Paint()
-        .apply { color = colorShade }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.CENTER }
-    private val paintCross = Paint()
-        .apply { color = colorCross }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.CENTER }
-
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        super.onLayout(changed, left, top, right, bottom)
-        if (changed) {
-            mHeight = height
-            paintNumber.apply { textSize = cellLength * 0.5F }
-            paintShade.apply { textSize = cellLength * 0.5F }
-            paintCross.apply { textSize = cellLength * 0.5F }
-        }
-    }
-
+class ColNumsView(context: Context) : AbstractNumsView(context) {
     private var initY = 0f
     private var transY = 0f
     private var oldTransY = 0f
@@ -91,11 +53,6 @@ class ColNumsView(context: Context) : View(context) {
         }
         return true
     }
-
-    private lateinit var templateNumber: MutableList<Picture>
-    private lateinit var templateShade: MutableList<Picture>
-    private lateinit var templateCross: MutableList<Picture>
-    var refreshTemplates = true
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)

--- a/app/src/main/java/com/picross/nonocross/views/grid/GridView.kt
+++ b/app/src/main/java/com/picross/nonocross/views/grid/GridView.kt
@@ -17,7 +17,6 @@ package com.picross.nonocross.views.grid
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.DialogInterface
-import android.content.SharedPreferences
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.util.AttributeSet
@@ -25,7 +24,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import androidx.appcompat.app.AppCompatActivity
-import androidx.preference.PreferenceManager
 import arrow.core.None
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.picross.nonocross.GameActivity
@@ -36,6 +34,7 @@ import com.picross.nonocross.HighScoreManager
 import com.picross.nonocross.LevelType
 import com.picross.nonocross.R
 import com.picross.nonocross.util.CellShade
+import com.picross.nonocross.util.Preferences
 import com.picross.nonocross.util.getRandomGridPrefs
 import com.picross.nonocross.util.resolveThemedColor
 import com.picross.nonocross.util.secondsToTime
@@ -53,9 +52,8 @@ class GridView @JvmOverloads constructor(
     private val colorCross =  context.resolveThemedColor(R.attr.colorCross)
     private val colorShade =  context.resolveThemedColor(R.attr.colorPrimary)
     private val colorEmpty = context.resolveThemedColor(R.attr.colorSurface)
-    private val preferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(context)
-    private val enableZoom = preferences.getBoolean("enable_zoom", true)
+    private val preferences = Preferences(context)
+    private val enableZoom = preferences.enableZoom
 
     private val paintEmpty = Paint().apply { color = colorEmpty }
     private val paintShade = Paint().apply { color = colorShade }
@@ -161,16 +159,9 @@ class GridView @JvmOverloads constructor(
     private lateinit var nonoGrid: UserGridView
 
     // Get Preferences
-    private val sharedPreferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(context)
-    private val fatFingerMode = sharedPreferences.getBoolean("fatFinger", true)
-    private val vibrateOn = sharedPreferences.getBoolean("vibrate", false)
-    private val fillMode = when (val fM = sharedPreferences.getString("fillMode", "Default")) {
-        "Lax" -> 0
-        "Default" -> 1
-        "Strict" -> 2
-        else -> 1
-    }
+    private val fatFingerMode = preferences.fatFingerMode
+    private val vibrateOn = preferences.vibrate
+    private val fillMode = preferences.fillMode
 
     private var isFirstCell = true
     private var isLongPress = false

--- a/app/src/main/java/com/picross/nonocross/views/grid/RowNumsView.kt
+++ b/app/src/main/java/com/picross/nonocross/views/grid/RowNumsView.kt
@@ -16,54 +16,17 @@ package com.picross.nonocross.views.grid
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.SharedPreferences
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Picture
 import android.view.MotionEvent
-import android.view.View
-import androidx.preference.PreferenceManager
 import com.picross.nonocross.GameActivity.TransformDetails.mScaleFactor
 import com.picross.nonocross.GameActivity.TransformDetails.mTransY
-import com.picross.nonocross.R
-import com.picross.nonocross.util.resolveThemedColor
 import kotlin.math.max
 import kotlin.math.min
 import com.picross.nonocross.LevelDetails as LD
 
-class RowNumsView(context: Context) : View(context) {
-
-    private val preferences: SharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(context)
-    private val blueHints = preferences.getBoolean("showBlueHints", false)
-    private val enableZoom = preferences.getBoolean("enable_zoom", true)
-
-    var cellLength = 0
-    private val colorNumber = context.resolveThemedColor(R.attr.colorOnSurface)
-    private val colorShade = context.resolveThemedColor(R.attr.colorPrimary)
-    private val colorCross = context.resolveThemedColor(R.attr.colorCross)
-    private val paintNumber = Paint()
-        .apply { color = colorNumber }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.RIGHT }
-    private val paintShade = Paint()
-        .apply { color = colorShade }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.RIGHT }
-    private val paintCross = Paint()
-        .apply { color = colorCross }
-        .apply { isAntiAlias = true }
-        .apply { textAlign = Paint.Align.RIGHT }
-
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        super.onLayout(changed, left, top, right, bottom)
-        if (changed) {
-            paintNumber.apply { textSize = cellLength * 0.5F }
-            paintShade.apply { textSize = cellLength * 0.5F }
-            paintCross.apply { textSize = cellLength * 0.5F }
-        }
-    }
-
+class RowNumsView(context: Context) : AbstractNumsView(context) {
     private var initX = 0f
     private var transX = 0f
     private var oldTransX = 0f
@@ -91,11 +54,6 @@ class RowNumsView(context: Context) : View(context) {
         return true
     }
 
-    private lateinit var templateNumber: MutableList<Picture>
-    private lateinit var templateShade: MutableList<Picture>
-    private lateinit var templateCross: MutableList<Picture>
-    var refreshTemplates = true
-
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         canvas.save()
@@ -108,7 +66,7 @@ class RowNumsView(context: Context) : View(context) {
             refreshTemplates = false
         }
 
-        if (blueHints) {
+        if (showHints) {
             var counter = 0
             LD.gridData.rowNums.forEachIndexed { i, col ->
                 col.reversed().forEachIndexed { j, num ->
@@ -131,8 +89,7 @@ class RowNumsView(context: Context) : View(context) {
                 }
 
             }
-        }
-        else {
+        } else {
             templateNumber.forEach { canvas.drawPicture(it) }
         }
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -5,13 +5,14 @@
 
         <SwitchPreferenceCompat
             app:key="vibrate"
+            app:defaultValue="false"
             app:summary="@string/vibrate_summary"
             app:title="@string/vibrate_title"
             android:widgetLayout="@layout/preference_material_switch" />
 
         <SwitchPreferenceCompat
-            app:defaultValue="true"
             app:key="fatFinger"
+            app:defaultValue="true"
             app:summary="@string/fat_finger_summary"
             app:title="@string/fat_finger_title"
             android:widgetLayout="@layout/preference_material_switch" />
@@ -31,9 +32,10 @@
             android:widgetLayout="@layout/preference_material_switch" />
 
         <ListPreference
+            app:key="fillMode"
             app:entries="@array/fill_mode_entries"
             app:entryValues="@array/fill_mode_entry_values"
-            app:key="fillMode"
+            app:defaultValue="Default"
             app:title="@string/overwrite_cell_mode"
             app:useSimpleSummaryProvider="true" />
 
@@ -45,6 +47,7 @@
             app:key="darkMode2"
             app:entries="@array/dark_mode_entries"
             app:entryValues="@array/dark_mode_entry_values"
+            app:defaultValue="System"
             app:title="@string/dark_mode"
             app:useSimpleSummaryProvider="true" />
 
@@ -73,6 +76,7 @@
         <SwitchPreferenceCompat
             app:dependency="tracktimer"
             app:key="timer"
+            app:defaultValue="true"
             app:summary="@string/show_timer_summary"
             app:title="@string/show_timer"
             app:useSimpleSummaryProvider="true"


### PR DESCRIPTION
All shared preference keys and default values are now in the new class `Preferences`.
`ListPreference` are returned as meaningful `Int` or `enum class`, so they can be used without parsing.

Also set default values for all settings, which fixes #83.